### PR TITLE
Thread branch Testing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,5 +21,8 @@ jobs:
       run: cmake -S. -Bbuild
     - name: Build
       run: cmake --build build --target all -v
+    - name: Manual Test
+      continue-on-error: true
+      run: ./build/bin/Foo
     - name: Test
       run: CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target test -v

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Check CPU
+      run: lscpu
     - name: Check cmake
       run: cmake --version
     - name: Configure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,14 +16,14 @@ jobs:
     - name: Check cmake
       run: cmake --version
     - name: Configure
-      run: cmake -S. -Bbuild -G "Xcode" -DCMAKE_CONFIGURATION_TYPES=Debug
+      run: cmake -S. -Bbuild -G "Xcode" -DCMAKE_CONFIGURATION_TYPES=RelWithDebInfo
     - name: Build
-      run: cmake --build build --config Debug --target ALL_BUILD -v
+      run: cmake --build build --config RelWithDebInfo --target ALL_BUILD -v
     - name: Manual Test
       continue-on-error: true
-      run: ./build/DEBUG/bin/Foo
+      run: ./build/RELEASE/bin/Foo
     - name: Test
-      run: CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --config Debug --target RUN_TESTS -v
+      run: CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --config RelWithDebInfo --target RUN_TESTS -v
   make:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,6 +19,9 @@ jobs:
       run: cmake -S. -Bbuild -G "Xcode" -DCMAKE_CONFIGURATION_TYPES=Debug
     - name: Build
       run: cmake --build build --config Debug --target ALL_BUILD -v
+    - name: Manual Test
+      continue-on-error: true
+      run: ./build/DEBUG/bin/Foo
     - name: Test
       run: CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --config Debug --target RUN_TESTS -v
   make:
@@ -31,5 +34,8 @@ jobs:
       run: cmake -S. -Bbuild
     - name: Build
       run: cmake --build build --target all -v
+    - name: Manual Test
+      continue-on-error: true
+      run: ./build/bin/Foo
     - name: Test
       run: CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target test -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 build*/
+.cache/
 
 CMakeLists.txt.user
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ message(STATUS "version: ${PROJECT_VERSION}")
 
 # Force default build type to RelWithDebInfo
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
     #set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
     "Choose the type of build, options are: Debug, Release (default), RelWithDebInfo and MinSizeRel."
     FORCE)
@@ -33,8 +33,8 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 option(CLANG_TSAN "Enable Clang thread sanitizer" ON)
 if (CLANG_TSAN)
-  set(CMAKE_C_FLAGS "-fsanitize=thread -O1")
-  set(CMAKE_CXX_FLAGS "-fsanitize=thread -O1")
+  set(CMAKE_C_FLAGS "-fsanitize=thread")
+  set(CMAKE_CXX_FLAGS "-fsanitize=thread")
 endif()
 
 # Layout build dir like install dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(NOT CMAKE_BUILD_TYPE)
     FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
-option(CLANG_TSAN "Enable Clang thread sanitizer" ON)
+option(CLANG_TSAN "Enable Clang thread sanitizer" OFF)
 if (CLANG_TSAN)
   set(CMAKE_C_FLAGS "-fsanitize=thread")
   set(CMAKE_CXX_FLAGS "-fsanitize=thread")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,20 +13,29 @@
 cmake_minimum_required(VERSION 3.18)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 project(MultiThread VERSION 0.1 LANGUAGES CXX)
 message(STATUS "project: ${PROJECT_NAME}")
 message(STATUS "version: ${PROJECT_VERSION}")
 
 # Force default build type to RelWithDebInfo
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING
+    #set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
     "Choose the type of build, options are: Debug, Release (default), RelWithDebInfo and MinSizeRel."
     FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+option(CLANG_TSAN "Enable Clang thread sanitizer" ON)
+if (CLANG_TSAN)
+  set(CMAKE_C_FLAGS "-fsanitize=thread -O1")
+  set(CMAKE_CXX_FLAGS "-fsanitize=thread -O1")
+endif()
 
 # Layout build dir like install dir
 include(GNUInstallDirs)

--- a/Foo/src/main.cpp
+++ b/Foo/src/main.cpp
@@ -116,7 +116,7 @@ int main(int /*argc*/, char** /*argv*/) {
   // Solve
   std::cerr << "Solve...\n";
 
-  SCIPsetIntParam(scip_, "parallel/maxnthreads", 4);
+  SCIPsetIntParam(scip_, "parallel/maxnthreads", 8);
   SCIPsolveConcurrent(scip_);
   //SCIPsolve(scip_);
 

--- a/Foo/src/main.cpp
+++ b/Foo/src/main.cpp
@@ -116,7 +116,7 @@ int main(int /*argc*/, char** /*argv*/) {
   // Solve
   std::cerr << "Solve...\n";
 
-  SCIPsetIntParam(scip_, "parallel/maxnthreads", 8);
+  SCIPsetIntParam(scip_, "parallel/maxnthreads", 4);
   SCIPsolveConcurrent(scip_);
   //SCIPsolve(scip_);
 


### PR DESCRIPTION
Play with thread number to see if CI pass more easily...
Currently test is flacky on github workers, can't reproduce it locally (even with using up to 64 threads)

FYI:
```sh
[paramset.c:113] ERROR: Invalid value <127> for int parameter <parallel/maxnthreads>. Must be in range [0,64].
[paramset.c:1993] ERROR: Error <-14> in function call
[set.c:3213] ERROR: Error <-14> in function call
[scip_param.c:487] ERROR: Error <-14> in function call
```